### PR TITLE
multi-threaded bench

### DIFF
--- a/_example/multi/multi_test.go
+++ b/_example/multi/multi_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"database/sql"
+	"math/rand"
+	"os"
+	"sort"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	_ "github.com/DataDog/go-sqlite3"
+)
+
+func appendTo(dbs []*sql.DB) {
+	append := func(db *sql.DB) {
+		num := rand.Intn(25)
+		str := strconv.Itoa(rand.Intn(10))
+		_, err := db.Exec("INSERT OR REPLACE INTO test (a, b) VALUES (?, ?);", num, str)
+		if err != nil {
+			panic(err)
+		}
+	}
+	var wg sync.WaitGroup
+	wg.Add(len(dbs))
+	for _, db := range dbs {
+		go func(db *sql.DB) {
+			append(db)
+			wg.Done()
+		}(db)
+	}
+	wg.Wait()
+}
+
+func BenchmarkMultiWrite(b *testing.B) {
+	paths := []string{"/tmp/__sqb1.db", "/tmp/__sqb2.db", "/tmp/__sqb3.db"}
+	defer func() {
+		for _, path := range paths {
+			os.Remove(path)
+		}
+	}()
+
+	var dbs []*sql.DB
+	for _, path := range paths {
+		db, err := sql.Open("sqlite3", path)
+		if err != nil {
+			b.Fatalf("error %s", err)
+		}
+		_, err = db.Exec("CREATE TABLE test (a int, b text);")
+		if err != nil {
+			b.Fatalf("ddl error %s", err)
+		}
+		dbs = append(dbs, db)
+	}
+
+	b.ResetTimer()
+
+	var tds []int
+	t0 := time.Now()
+	for i := 0; i < b.N; i++ {
+		appendTo(dbs)
+		td := time.Since(t0)
+		tds = append(tds, int(td))
+		t0 = time.Now()
+	}
+
+	b.StopTimer()
+
+	sort.Sort(sort.Reverse(sort.IntSlice(tds)))
+
+	if len(tds) > 3 && tds[0] > int(time.Millisecond*100) {
+		b.Log("slow bench, top 3:")
+		for _, td := range tds[:3] {
+			b.Logf(" %s", time.Duration(td))
+		}
+	}
+
+	total := 0
+	for _, db := range dbs {
+		rows, err := db.Query("SELECT COUNT(*) FROM test;")
+		if err != nil {
+			b.Fatalf("select err %s", err)
+		}
+		if !rows.Next() {
+			b.Fatal("no next")
+		}
+		var num int
+		err = rows.Scan(&num)
+		if err != nil {
+			b.Fatalf("scan err %s", err)
+		}
+		rows.Close()
+		total += num
+	}
+
+	for _, db := range dbs {
+		db.Close()
+	}
+
+	b.Log("total rows:", total)
+}

--- a/_example/multi/multi_test.go
+++ b/_example/multi/multi_test.go
@@ -70,7 +70,14 @@ func BenchmarkMultiWrite(b *testing.B) {
 	sort.Sort(sort.Reverse(sort.IntSlice(tds)))
 
 	if len(tds) > 3 && tds[0] > int(time.Millisecond*100) {
-		b.Log("slow bench, top 3:")
+		var sum int
+		for _, td := range tds {
+			sum += td
+		}
+		avg := time.Duration(sum / len(tds))
+		// not the real median but close enough
+		median := time.Duration(tds[len(tds)/2])
+		b.Logf("slow bench, top 3 (median: %s, avg: %s):", median, avg)
 		for _, td := range tds[:3] {
 			b.Logf(" %s", time.Duration(td))
 		}

--- a/_example/multi/multi_test.go
+++ b/_example/multi/multi_test.go
@@ -43,7 +43,7 @@ func BenchmarkMultiWrite(b *testing.B) {
 	}()
 	var dsns []string
 	for _, path := range paths {
-		dsns = append(dsns, fmt.Sprintf("file:%s?busy_timeout=5", path))
+		dsns = append(dsns, fmt.Sprintf("file:%s?_busy_timeout=5", path))
 	}
 
 	var dbs []*sql.DB

--- a/_example/multi/multi_test.go
+++ b/_example/multi/multi_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
+	"path"
 	"sort"
 	"strconv"
 	"sync"
@@ -35,7 +36,16 @@ func appendTo(sts []*sql.Stmt) {
 }
 
 func BenchmarkMultiWrite(b *testing.B) {
-	paths := []string{"/tmp/__sqb1.db", "/tmp/__sqb2.db", "/tmp/__sqb3.db"}
+	tmp := os.Getenv("TMP")
+	if len(tmp) == 0 {
+		tmp = "/tmp"
+	}
+	paths := []string{
+		path.Join(tmp, "__sqb1.db"),
+		path.Join(tmp, "__sqb2.db"),
+		path.Join(tmp, "__sqb3.db"),
+	}
+
 	defer func() {
 		for _, path := range paths {
 			os.Remove(path)


### PR DESCRIPTION
This benchmark attempts to do inserts into multiple different sqlite3 dbs at a time.  It seems to demonstrate that this can take much longer than one would expect:

```sh
$GOPATH/src/github.com/DataDog/go-sqlite3/_example/multi (jason/multi-test *)$ go test -bench . -v
BenchmarkMultiWrite-4   	      50	 131837868 ns/op
--- BENCH: BenchmarkMultiWrite-4
	multi_test.go:108: total rows: 3
	multi_test.go:108: total rows: 6
	multi_test.go:108: total rows: 9
	multi_test.go:80: slow bench, top 3 (median: 33.655557ms, avg: 131.837148ms):
	multi_test.go:82:  1.299541798s
	multi_test.go:82:  673.901154ms
	multi_test.go:82:  664.089833ms
	multi_test.go:108: total rows: 150
PASS
ok  	github.com/DataDog/go-sqlite3/_example/multi	8.391s
```

This is _already_ including the the usleep patch, so it's not that.